### PR TITLE
Added pipe for friendly url name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,3 +4,4 @@
 export { NgBreadcrumbModule } from './src/app/components/breadcrumb/breadcrumb.module';
 export { BreadcrumbComponent } from './src/app/components/breadcrumb/breadcrumb.component';
 export { BreadcrumbService }   from './src/app/components/breadcrumb/breadcrumb.service';
+export { FriendlyNamePipe } from './src/app/components/breadcrumb/friendly-name.pipe';

--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -12,9 +12,9 @@ import {BreadcrumbService} from './breadcrumb.service';
         <ul [class.breadcrumb]="useBootstrap">
             <li *ngFor="let url of _urls; let last = last" [ngClass]="{'breadcrumb-item': useBootstrap, 'active': last}"> <!-- disable link of last item -->
                 <a role="button" *ngIf="!last && url == prefix" (click)="navigateTo('/')">{{url}}</a>
-                <a role="button" *ngIf="!last && url != prefix" (click)="navigateTo(url)">{{friendlyName(url)}}</a>
-                <span *ngIf="last">{{friendlyName(url)}}</span>
-                <span *ngIf="last && url == prefix">{{friendlyName('/')}}</span>
+                <a role="button" *ngIf="!last && url != prefix" (click)="navigateTo(url)">{{url | friendlyName}}</a>
+                <span *ngIf="last">{{url | friendlyName}}</span>
+                <span *ngIf="last && url == prefix">{{'/' | friendlyName}}</span>
             </li>
         </ul>
     `
@@ -45,7 +45,7 @@ export class BreadcrumbComponent implements OnInit, OnChanges {
 
         this._routerSubscription = this.router.events.subscribe((navigationEnd:NavigationEnd) => {
 
-           if (navigationEnd instanceof NavigationEnd) {
+            if (navigationEnd instanceof NavigationEnd) {
                 this._urls.length = 0; //Fastest way to clear out array
                 this.generateBreadcrumbTrail(navigationEnd.urlAfterRedirects ? navigationEnd.urlAfterRedirects : navigationEnd.url);
             }
@@ -76,10 +76,6 @@ export class BreadcrumbComponent implements OnInit, OnChanges {
 
     navigateTo(url: string): void {
         this.router.navigateByUrl(url);
-    }
-
-    friendlyName(url: string): string {
-        return !url ? '' : this.breadcrumbService.getFriendlyNameForRoute(url);
     }
 
     ngOnDestroy(): void {

--- a/src/app/components/breadcrumb/breadcrumb.module.ts
+++ b/src/app/components/breadcrumb/breadcrumb.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { BreadcrumbComponent } from './breadcrumb.component';
 import { BreadcrumbService } from './breadcrumb.service';
+import { FriendlyNamePipe } from './friendly-name.pipe';
 
 export * from './breadcrumb.component';
 export * from './breadcrumb.service';
@@ -12,7 +13,8 @@ export * from './breadcrumb.service';
     CommonModule
   ],
   declarations: [
-    BreadcrumbComponent
+    BreadcrumbComponent,
+    FriendlyNamePipe
   ],
   exports: [
     BreadcrumbComponent

--- a/src/app/components/breadcrumb/friendly-name.pipe.ts
+++ b/src/app/components/breadcrumb/friendly-name.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {BreadcrumbService} from './breadcrumb.service';
+
+@Pipe({
+  name: 'friendlyName'
+})
+export class FriendlyNamePipe implements PipeTransform {
+
+  constructor(private breadcrumbService: BreadcrumbService) {}
+
+  transform(url: string): any {
+    return this.breadcrumbService.getFriendlyNameForRoute(url);
+  }
+
+}


### PR DESCRIPTION
When using the breadcrumb in my own project, the angular profiler shows that a lot of processing time is used for the `BreadcrumbComponent`. The reason for this, is that its template uses the `friendlyName`-function in multiple places which are called in every change detection cycle. The component from my project I used for testing is pretty complex, with some parts which don't have a good performance but still the breadcrumb comes out on top.

![image](https://user-images.githubusercontent.com/8479506/68274804-5c1a9200-006a-11ea-9520-5867f5ab96a0.png)

This pull request introduces a new `FriendlyNamePipe` which has the same functionality as the template function. But as pipes in angular are only called once and if the given input parameter changes (here `url` as `string`), it reduces the general cpu load. In the project example app the number of change detection cycles and thus the frame rate increases by a factor of ~10.

Without pipe:
![before pipe](https://user-images.githubusercontent.com/8479506/68275304-8caefb80-006b-11ea-97c0-537d7570ef79.png)

With pipe:
![after pipe](https://user-images.githubusercontent.com/8479506/68275313-920c4600-006b-11ea-9ba1-ad9a9e72d799.png)
